### PR TITLE
Vagrantfile, provision_script.sh and updated README.md.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
    JSCity is an implementation of the Code City metaphor for visualizing source code. We adapted and implemented this metaphor for JavaScript, using the three.js 3D library.
    JSCity represents a JavaScript program as a city; folders are districts and files are sub-districts; the buildings are functions; inner functions are represented as buildings on the top of their nested function/building.
    The Number Of Lines of Source (LOC) represents the height of the buildings/functions; the Number Of Variables (NOV) in a function correlates to the building's base size. Blue buildings denote named functions; green buildings are anonymous functions.
-   
+
    For examples of cities check: [Wiki](https://github.com/ASERG-UFMG/JSCity/wiki/JSCITY).
-   
+
 ### Steps to see your first 3D Javascript City.
+You can set up from source directly, or see Vagrant setup below.
+
 * Install nodejs. You can download it from [https://nodejs.org/en/](https://nodejs.org/en/).
 * Install MySQL Server (https://dev.mysql.com/downloads/mysql/).  If you already have the mysql on your computer jump to step * Start the MySQL server.
 * Run the script **schema.sql** located inside of sql diretory.
@@ -33,6 +35,21 @@ http://localhost:800/
 ```
 * Select the system from the combobox and wait for the end of city design.
 
+### Vagrant setup
+
+Alternatively, you can install [Vagrant](https://www.vagrantup.com).  There is
+a Vagrantfile and shell provision script, which will start up an Ubuntu 14.04
+virtual machine instance, install MySQL and Node in it and configure them
+properly. You can then run:
+```sh
+vagrant up
+```
+* Use your browser access the url below to open the jscity system:
+```
+http://localhost:8080/
+```
+Note that this is a different URL than the source default above.
+
 ### How to generate a city
 
 * Certifiy that you have [nodejs](https://nodejs.org/en/) and [MySQL server](https://dev.mysql.com/downloads/mysql/) installed on your computer.
@@ -44,7 +61,7 @@ path-to-jscity-directory/js/backend/system/
 * Open nodeJs console and go to the js directory from JSCity
 ```sh
 cd /path-to-jscity-directory/js
-``` 
+```
 * Start the application server using the command:
 ```sh
 node serve.js

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,68 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network "forwarded_port", guest: 800, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", path: "provision_script.sh"
+end

--- a/provision_script.sh
+++ b/provision_script.sh
@@ -1,0 +1,15 @@
+# provision_script.sh
+apt-get update
+debconf-set-selections <<< 'mysql-server mysql-server/root_password password your_password'
+debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password your_password'
+apt-get -y install mysql-server
+apt-get -y install nodejs
+cd /vagrant
+/usr/bin/mysql --user=root --password=your_password < sql/schema.sql
+/usr/bin/perl -i.bak -ne 's/"password": ""/"password": "your_password"/g; print;' js/config.json
+/usr/bin/nodejs js/server.js > /var/log/node-server-log.log 2>&1 &
+echo ""
+echo "------------------------------------------------------"
+echo "You can now visit http://localhost:8080 to see a city!"
+echo "------------------------------------------------------"
+echo ""


### PR DESCRIPTION
Some folks like to run things in a virtual machine, rather than installing things such as MySQL, Node, etc. directly.

Accordingly, this sets up a Vagrantfile and a provisioner script to set things up automatically.  I've done a minimal edit on README.md to document this alternative; please feel free to improve on it as necessary.

Thanks for doing JSCity!  It's quite impressive.
